### PR TITLE
fixing rock paper scissors script

### DIFF
--- a/rps.py
+++ b/rps.py
@@ -10,7 +10,7 @@ def play():
     if is_win(user, computer):
         return 'You won!'
 
-     return 'you lost'
+        return 'you lost'
 
 
 def is_win(player, opponent):


### PR DESCRIPTION
rock paper scissors script was failing because the return you lost was improperly indented.